### PR TITLE
Bump to 22.03

### DIFF
--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.1cxx_compiler_version10python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.1cxx_compiler_version10python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
-numpy:
-- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.1cxx_compiler_version10python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.1cxx_compiler_version10python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.1cxx_compiler_version10python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.1cxx_compiler_version10python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
-numpy:
-- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compiler_version11.2cxx_compiler_version10python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-numpy:
-- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compiler_versionNonecxx_compiler_version11python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
-numpy:
-- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version9cuda_compiler_version11.0cxx_compiler_version9python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version9cuda_compiler_version11.0cxx_compiler_version9python3.10.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
-numpy:
-- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version9cuda_compiler_version11.0cxx_compiler_version9python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version9cuda_compiler_version11.0cxx_compiler_version9python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_c_compiler_version9cuda_compiler_version11.0cxx_compiler_version9python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version9cuda_compiler_version11.0cxx_compiler_version9python3.9.____cpython.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
-numpy:
-- '1.20'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -36,5 +34,3 @@ zip_keys:
   - cuda_compiler_version
   - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,9 @@ outputs:
   - name: nvidia-apex
     version: {{ version }}
     build:
-      script: python -m pip install . -vv
+      script:
+        - export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
+        - python -m pip install . -vv
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,7 @@
 {% set version = "22.03" %}
 
-{% set nvidia_apex_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}  # [linux64]
-{% set nvidia_apex_proc_type = "cpu" %}                                                # [not linux64]
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
-{% set torch_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
+{% set proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 
 package:
   name: nvidia-apex-split
@@ -21,7 +19,7 @@ outputs:
   - name: nvidia-apex-proc
     version: {{ version }}
     build:
-      string: "{{ nvidia_apex_proc_type }}"
+      string: "{{ proc_type }}"
     test:
       commands:
         - exit 0
@@ -34,6 +32,8 @@ outputs:
   - name: nvidia-apex
     version: {{ version }}
     build:
+      string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [cuda_compiler_version == "None"]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
       script:
         - export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
         - python -m pip install . -vv
@@ -45,7 +45,7 @@ outputs:
       host:
         - python
         - pytorch
-        - pytorch =*={{ torch_proc_type }}*
+        - pytorch =*={{ proc_type }}*
         - setuptools
         - pip
       run:
@@ -56,8 +56,10 @@ outputs:
         - PyYAML
         - pytest
       run_constrained:
-        - nvidia-apex-proc * {{ nvidia_apex_proc_type }}
-        - pytorch =*={{ torch_proc_type }}*
+        # old constraint used "gpu"
+        - nvidia-apex-proc =*=cuda|=*=gpu  # [cuda_compiler_version != "None"]
+        - nvidia-apex-proc =*=cpu          # [cuda_compiler_version != "None"]
+        - pytorch =*={{ proc_type }}*
     test:
       imports:
         - apex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-{% set name = "nvidia-apex" %}
 {% set version = "0.1" %}
 {% set commit = "088985936518be7e25795a30d8ab33affa9db6ed" %}
 
@@ -8,7 +7,7 @@
 {% set torch_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 
 package:
-  name: {{ name|lower }}
+  name: nvidia-apex
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "22.03" %}
+{% set proc_version = "1.0.0" %}
 
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 {% set proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
@@ -17,9 +18,9 @@ build:
 
 outputs:
   - name: nvidia-apex-proc
-    version: {{ version }}
+    version: {{ proc_version }}
     build:
-      string: "{{ proc_type }}"
+      string: {{ proc_type }}
     test:
       commands:
         - exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
-{% set version = "0.1" %}
-{% set commit = "088985936518be7e25795a30d8ab33affa9db6ed" %}
+{% set version = "22.03" %}
 
 {% set nvidia_apex_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}  # [linux64]
 {% set nvidia_apex_proc_type = "cpu" %}                                                # [not linux64]
@@ -11,11 +10,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/NVIDIA/apex/archive/{{ commit }}.tar.gz
-  sha256: cc5ce27aa30b5ade54d520fafc1cd7d293dfba58c51851759a034d03e3f370bb
+  url: https://github.com/NVIDIA/apex/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 694f1ac1aaed6435b2f0c2ebc1af56b8a215a5eaa96c2565a578e8734378ff66
 
 build:
-  number: 7
+  number: 0
   skip: True  # [osx or win]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set torch_proc_type = "cuda" if cuda_compiler_version != "None" else "cpu" %}
 
 package:
-  name: nvidia-apex
+  name: nvidia-apex-split
   version: {{ version }}
 
 source:
@@ -89,3 +89,4 @@ extra:
     - benhuff
     - jakirkham
     - rluria14
+  feedstock-name: nvidia-apex


### PR DESCRIPTION
As I feared, the tests weren't actually run due to 2ebaf2b3683c8a07cd16cd9b303f47d9dee677c3, meaning that we didn't see that the published packages are actually incompatible (see #26).
```
 from torch._six import container_abcs
ImportError: cannot import name 'container_abcs' from 'torch._six' ([...]/lib/python3.10/site-packages/torch/_six.py)

```

Let's see if the new tag that appeared upstream fixes this.
